### PR TITLE
Only get solar data when solar tools are used

### DIFF
--- a/src/main/java/ca/milieux/sunblock/core/application/client/ClientEventHandler.java
+++ b/src/main/java/ca/milieux/sunblock/core/application/client/ClientEventHandler.java
@@ -27,8 +27,8 @@ public class ClientEventHandler {
 	@SubscribeEvent
 	public void onBlockStartBreak(PlayerEvent.BreakSpeed event){
 		String item = event.getEntity().getMainHandItem().toString();
-		float inc_speed = Math.max(DataQueryProcess.GetServerData(SolarDataTypes.PVPOWER), event.getOriginalSpeed());
 		if (item.contains("solar_pickaxe") || item.contains("solar_shovel")){
+			float inc_speed = Math.max(DataQueryProcess.GetServerData(SolarDataTypes.PVPOWER), event.getOriginalSpeed());
 			event.setNewSpeed(inc_speed);
 		}
 	}


### PR DESCRIPTION
Currently the mod looks up solar server data every time the BreakSpeed event is fired, which causes FPS drops. This change should prevent this from happening unless solar tools are used.